### PR TITLE
fix missing namespace

### DIFF
--- a/examples/accel/index.js
+++ b/examples/accel/index.js
@@ -2,7 +2,7 @@
 let ganglion;
 
 const onConnectClick = async () => {
-    ganglion = new Ganglion({ accelData: true });
+    ganglion = new Ganglion.Ganglion({ accelData: true });
     await ganglion.connect();
     await ganglion.start();
     ganglion.accelData

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -2,7 +2,7 @@
 let ganglion;
 
 const onConnectClick = async () => {
-    ganglion = new Ganglion();
+    ganglion = new Ganglion.Ganglion();
     await ganglion.connect();
     await ganglion.start();
     ganglion.stream.subscribe(sample => {


### PR DESCRIPTION
After trying to run the examples, I noticed that the Ganglion object is contained within the Ganglion namespace (e.g. `new Ganglion()` vs. `new Ganglion.Ganglion()`). This was missing from the both examples' index.js. Let me know if this is an issue with how I ran the examples vs. an issue with the examples themselves.

Steps to reproduce the error:
```
git clone https://github.com/alexcastillo/ganglion-ble
cd ganglion-ble
npm install
```

Versions:
- npm -> 5.6.0
- node -> v9.5.0